### PR TITLE
[refactor] status있는 entity에 updatedAt, deletedAt추가

### DIFF
--- a/src/main/java/xyz/iwasacar/api/domain/consenthistories/entity/DocumentConsentHistory.java
+++ b/src/main/java/xyz/iwasacar/api/domain/consenthistories/entity/DocumentConsentHistory.java
@@ -1,4 +1,4 @@
-package xyz.iwasacar.api.domain.agreementhistories.entity;
+package xyz.iwasacar.api.domain.consenthistories.entity;
 
 import java.time.LocalDateTime;
 
@@ -57,5 +57,11 @@ public class DocumentConsentHistory {
 	@Column(name = "created_at", nullable = false)
 	@CreationTimestamp
 	private LocalDateTime createdAt;
+
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
 
 }

--- a/src/main/java/xyz/iwasacar/api/domain/documentitems/entity/DocumentItem.java
+++ b/src/main/java/xyz/iwasacar/api/domain/documentitems/entity/DocumentItem.java
@@ -51,4 +51,10 @@ public class DocumentItem {
 	@CreationTimestamp
 	private LocalDateTime createdAt;
 
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
 }

--- a/src/main/java/xyz/iwasacar/api/domain/documents/entity/Document.java
+++ b/src/main/java/xyz/iwasacar/api/domain/documents/entity/Document.java
@@ -43,4 +43,10 @@ public class Document {
 	@CreationTimestamp
 	private LocalDateTime createdAt;
 
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
 }

--- a/src/main/java/xyz/iwasacar/api/domain/histories/entity/PurchaseHistory.java
+++ b/src/main/java/xyz/iwasacar/api/domain/histories/entity/PurchaseHistory.java
@@ -77,4 +77,9 @@ public class PurchaseHistory {
 	@CreationTimestamp
 	private LocalDateTime createAt;
 
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
 }

--- a/src/main/java/xyz/iwasacar/api/domain/histories/entity/SaleHistory.java
+++ b/src/main/java/xyz/iwasacar/api/domain/histories/entity/SaleHistory.java
@@ -70,4 +70,10 @@ public class SaleHistory {
 	@CreationTimestamp
 	private LocalDateTime createAt;
 
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
 }

--- a/src/main/java/xyz/iwasacar/api/domain/members/entity/Member.java
+++ b/src/main/java/xyz/iwasacar/api/domain/members/entity/Member.java
@@ -67,4 +67,7 @@ public class Member {
 	@Column(name = "last_login_at", nullable = false)
 	private LocalDateTime lastLoginAt;
 
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
 }

--- a/src/main/java/xyz/iwasacar/api/domain/products/entity/Product.java
+++ b/src/main/java/xyz/iwasacar/api/domain/products/entity/Product.java
@@ -101,4 +101,10 @@ public class Product {
 	@CreationTimestamp
 	private LocalDateTime createdAt;
 
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
 }

--- a/src/main/java/xyz/iwasacar/api/domain/resources/entity/Resource.java
+++ b/src/main/java/xyz/iwasacar/api/domain/resources/entity/Resource.java
@@ -43,4 +43,9 @@ public class Resource {
 	@Column(name = "original_name", nullable = false)
 	private String originalName;
 
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
 }


### PR DESCRIPTION
## 구현 기능

* Entity 수정

## 세부 작업 내용

* [x] DB 테이블 status 관리를 생성, 수정 삭제로 관리하고자, 생성일자, 수정일자, 삭제일자를 추가
* [x] 따라서 도메인 별 status field를 가지고 있는 Entity에 updatedAt, deletedAt을 추가
* [x] 패키지이름 agreementhistories -> consenthistories로 변경




