### PR TITLE
[feat] 구매 내역 저장 API

### DIFF
--- a/src/main/java/xyz/iwasacar/api/common/aop/LogAspect.java
+++ b/src/main/java/xyz/iwasacar/api/common/aop/LogAspect.java
@@ -41,6 +41,7 @@ public class LogAspect {
 		String destination = getRequest().getRequestURI();
 		String id = UuidContext.getUuid();
 		log.error("EXCEPTION [{}] {} {}", id, destination, ex.getMessage());
+		log.error("", ex);
 	}
 
 	private HttpServletRequest getRequest() {

--- a/src/main/java/xyz/iwasacar/api/common/config/WebMvcConfig.java
+++ b/src/main/java/xyz/iwasacar/api/common/config/WebMvcConfig.java
@@ -19,7 +19,7 @@ import xyz.iwasacar.api.common.interceptor.BearerAuthInterceptor;
 public class WebMvcConfig implements WebMvcConfigurer {
 
 	@Value("${client-url}")
-	private String clientUrl;
+	private String[] clientUrl;
 
 	private final JwtTokenParser parser;
 	private final JwtTokenProvider provider;

--- a/src/main/java/xyz/iwasacar/api/common/exception/base/ExceptionStatus.java
+++ b/src/main/java/xyz/iwasacar/api/common/exception/base/ExceptionStatus.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum ExceptionStatus {
-
 	LOGIN_FAIL(401, "", UNAUTHORIZED),
 
 	AUTHORIZE_FORBIDDEN(403, "", FORBIDDEN),

--- a/src/main/java/xyz/iwasacar/api/domain/banks/exception/BankNotFound.java
+++ b/src/main/java/xyz/iwasacar/api/domain/banks/exception/BankNotFound.java
@@ -1,0 +1,12 @@
+package xyz.iwasacar.api.domain.banks.exception;
+
+import xyz.iwasacar.api.common.exception.base.BaseAbstractException;
+import xyz.iwasacar.api.common.exception.base.ExceptionStatus;
+
+public class BankNotFound extends BaseAbstractException {
+
+	public BankNotFound() {
+		super(ExceptionStatus.Bank_NOT_FOUNT);
+	}
+
+}

--- a/src/main/java/xyz/iwasacar/api/domain/histories/controller/HistoryController.java
+++ b/src/main/java/xyz/iwasacar/api/domain/histories/controller/HistoryController.java
@@ -15,18 +15,17 @@ import xyz.iwasacar.api.domain.histories.dto.response.PurchaseHistoryResponse;
 import xyz.iwasacar.api.domain.histories.service.HistoryService;
 
 @RestController
-@RequestMapping("api/v1/histories")
+@RequestMapping("/api/v1/histories")
 @RequiredArgsConstructor
 public class HistoryController {
 
 	private final HistoryService historyService;
 
 	@PostMapping("/purchase")
-	// ResponseEntity<CommonResponse<>>
 	public ResponseEntity<CommonResponse<PurchaseHistoryResponse>> savePurchaseHistory(
 		@RequestBody PurchaseHistoryRequest purchaseHistoryRequest) {
 		PurchaseHistoryResponse savedpurchaseHistory = historyService.savePurchaseHistory(purchaseHistoryRequest);
-		return CommonResponse.success(OK, OK.value(), savedpurchaseHistory);
+		return CommonResponse.success(CREATED, CREATED.value(), savedpurchaseHistory);
 	}
 
 }

--- a/src/main/java/xyz/iwasacar/api/domain/histories/controller/HistoryController.java
+++ b/src/main/java/xyz/iwasacar/api/domain/histories/controller/HistoryController.java
@@ -1,0 +1,32 @@
+package xyz.iwasacar.api.domain.histories.controller;
+
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import xyz.iwasacar.api.common.dto.response.CommonResponse;
+import xyz.iwasacar.api.domain.histories.dto.request.PurchaseHistoryRequest;
+import xyz.iwasacar.api.domain.histories.dto.response.PurchaseHistoryResponse;
+import xyz.iwasacar.api.domain.histories.service.HistoryService;
+
+@RestController
+@RequestMapping("api/v1/histories")
+@RequiredArgsConstructor
+public class HistoryController {
+
+	private final HistoryService historyService;
+
+	@PostMapping("/purchase")
+	// ResponseEntity<CommonResponse<>>
+	public ResponseEntity<CommonResponse<PurchaseHistoryResponse>> savePurchaseHistory(
+		@RequestBody PurchaseHistoryRequest purchaseHistoryRequest) {
+		PurchaseHistoryResponse savedpurchaseHistory = historyService.savePurchaseHistory(purchaseHistoryRequest);
+		return CommonResponse.success(OK, OK.value(), savedpurchaseHistory);
+	}
+
+}

--- a/src/main/java/xyz/iwasacar/api/domain/histories/dto/request/PurchaseHistoryRequest.java
+++ b/src/main/java/xyz/iwasacar/api/domain/histories/dto/request/PurchaseHistoryRequest.java
@@ -1,0 +1,61 @@
+package xyz.iwasacar.api.domain.histories.dto.request;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class PurchaseHistoryRequest {
+	/*
+	@RequestBody Long memberId, @RequestBody Long productId, @RequestBody Long bankId,
+		@RequestBody Long loanId, @RequestBody Long insuranceId, @RequestBody Integer zipCode,
+		@RequestBody String address,
+		@RequestBody String addressDetail, @RequestBody String accountNumber, @RequestBody String account_holder,
+		@RequestBody LocalDateTime deliverySchedule
+	 */
+	private final Long memberId;
+
+	private final Long productId;
+
+	private final Long bankId;
+
+	private final Long loanId;
+
+	private final Long insuranceId;
+
+	private final Integer zipCode;
+
+	private final String address;
+
+	private final String addressDetail;
+
+	private final String accountNumber;
+
+	private final String accountHolder;
+
+	private final LocalDateTime deliverySchedule;
+
+	// final을 붙인 경우 생성자를 쓰려면 생성자 만들고 @JsonCreator가 있어야 Joson 형태로 만들어준다.
+	// 원래는 final 안 붙이고 기본 생성자 어노테이션 class에 붙임
+	@JsonCreator
+	public PurchaseHistoryRequest(Long memberId, Long productId, Long bankId, Long loanId, Long insuranceId,
+		Integer zipcode, String address, String addressDetail, String accountNumber, String accountHolder,
+		@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime deliverySchedule) {
+		this.memberId = memberId;
+		this.productId = productId;
+		this.bankId = bankId;
+		this.loanId = loanId;
+		this.insuranceId = insuranceId;
+		this.zipCode = zipcode;
+		this.address = address;
+		this.addressDetail = addressDetail;
+		this.accountNumber = accountNumber;
+		this.accountHolder = accountHolder;
+		this.deliverySchedule = deliverySchedule;
+	}
+}

--- a/src/main/java/xyz/iwasacar/api/domain/histories/dto/request/PurchaseHistoryRequest.java
+++ b/src/main/java/xyz/iwasacar/api/domain/histories/dto/request/PurchaseHistoryRequest.java
@@ -11,13 +11,7 @@ import lombok.ToString;
 @Getter
 @ToString
 public class PurchaseHistoryRequest {
-	/*
-	@RequestBody Long memberId, @RequestBody Long productId, @RequestBody Long bankId,
-		@RequestBody Long loanId, @RequestBody Long insuranceId, @RequestBody Integer zipCode,
-		@RequestBody String address,
-		@RequestBody String addressDetail, @RequestBody String accountNumber, @RequestBody String account_holder,
-		@RequestBody LocalDateTime deliverySchedule
-	 */
+	
 	private final Long memberId;
 
 	private final Long productId;

--- a/src/main/java/xyz/iwasacar/api/domain/histories/dto/response/PurchaseHistoryResponse.java
+++ b/src/main/java/xyz/iwasacar/api/domain/histories/dto/response/PurchaseHistoryResponse.java
@@ -1,0 +1,51 @@
+package xyz.iwasacar.api.domain.histories.dto.response;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import xyz.iwasacar.api.domain.histories.entity.PurchaseHistory;
+
+@Builder
+@Getter
+@RequiredArgsConstructor
+public class PurchaseHistoryResponse {
+	private final Long id;
+
+	private final String memberName;
+
+	private final Long productId;
+
+	private final String productName;
+
+	private final String bankName;
+
+	private final String loanName;
+
+	private final String insuranceName;
+
+	private final Integer zipCode;
+
+	private final String address;
+
+	private final String addressDetail;
+
+	private final String accountNumber;
+
+	private final String accountHolder;
+
+	private final LocalDateTime deliverySchedule;
+
+	private final LocalDateTime createAt;
+
+	public static PurchaseHistoryResponse of(PurchaseHistory purchaseHistory) {
+		return new PurchaseHistoryResponse(purchaseHistory.getId(), purchaseHistory.getMember().getName(),
+			purchaseHistory.getProduct().getId(), purchaseHistory.getProduct().getName(),
+			purchaseHistory.getBank().getName(), purchaseHistory.getLoan().getName(),
+			purchaseHistory.getInsurance().getName(), purchaseHistory.getZipCode(), purchaseHistory.getAddress(),
+			purchaseHistory.getAddressDetail(), purchaseHistory.getAccountNumber(), purchaseHistory.getAccountHolder(),
+			purchaseHistory.getDeliverySchedule(), purchaseHistory.getCreateAt());
+	}
+
+}

--- a/src/main/java/xyz/iwasacar/api/domain/histories/entity/PurchaseHistory.java
+++ b/src/main/java/xyz/iwasacar/api/domain/histories/entity/PurchaseHistory.java
@@ -13,8 +13,10 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import xyz.iwasacar.api.domain.banks.entity.Bank;
@@ -64,6 +66,9 @@ public class PurchaseHistory {
 	@Column(name = "address_detail", nullable = false)
 	private String addressDetail;
 
+	@Column(name = "account_number", nullable = false, length = 20)
+	private String accountNumber;
+
 	@Column(name = "account_holder", nullable = false, length = 20)
 	private String accountHolder;
 
@@ -73,13 +78,33 @@ public class PurchaseHistory {
 	@Column(name = "status", nullable = false, length = 20)
 	private EntityStatus status;
 
-	@Column(name = "create_at", nullable = false)
+	@Column(name = "created_at", nullable = false)
 	@CreationTimestamp
 	private LocalDateTime createAt;
 
 	@Column(name = "updated_at", nullable = false)
+	@UpdateTimestamp
 	private LocalDateTime updatedAt;
 
 	@Column(name = "deleted_at")
 	private LocalDateTime deletedAt;
+
+	@Builder
+	public PurchaseHistory(Member member, Product product, Bank bank, Loan loan, Insurance insurance, Integer zipCode,
+		String address, String addressDetail, String accountNumber, String accountHolder,
+		LocalDateTime deliverySchedule,
+		EntityStatus status) {
+		this.member = member;
+		this.product = product;
+		this.bank = bank;
+		this.loan = loan;
+		this.insurance = insurance;
+		this.zipCode = zipCode;
+		this.address = address;
+		this.addressDetail = addressDetail;
+		this.accountNumber = accountNumber;
+		this.accountHolder = accountHolder;
+		this.deliverySchedule = deliverySchedule;
+		this.status = status;
+	}
 }

--- a/src/main/java/xyz/iwasacar/api/domain/histories/repository/PurchaseHistoryRepository.java
+++ b/src/main/java/xyz/iwasacar/api/domain/histories/repository/PurchaseHistoryRepository.java
@@ -1,0 +1,8 @@
+package xyz.iwasacar.api.domain.histories.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import xyz.iwasacar.api.domain.histories.entity.PurchaseHistory;
+
+public interface PurchaseHistoryRepository extends JpaRepository<PurchaseHistory, Long> {
+}

--- a/src/main/java/xyz/iwasacar/api/domain/histories/service/DefaultHistoryService.java
+++ b/src/main/java/xyz/iwasacar/api/domain/histories/service/DefaultHistoryService.java
@@ -1,0 +1,82 @@
+package xyz.iwasacar.api.domain.histories.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import xyz.iwasacar.api.domain.banks.entity.Bank;
+import xyz.iwasacar.api.domain.banks.exception.BankNotFound;
+import xyz.iwasacar.api.domain.banks.repository.BankRepository;
+import xyz.iwasacar.api.domain.common.constant.EntityStatus;
+import xyz.iwasacar.api.domain.histories.dto.request.PurchaseHistoryRequest;
+import xyz.iwasacar.api.domain.histories.dto.response.PurchaseHistoryResponse;
+import xyz.iwasacar.api.domain.histories.entity.PurchaseHistory;
+import xyz.iwasacar.api.domain.histories.repository.PurchaseHistoryRepository;
+import xyz.iwasacar.api.domain.insurances.entity.Insurance;
+import xyz.iwasacar.api.domain.insurances.exception.InsuranceNotFound;
+import xyz.iwasacar.api.domain.insurances.repository.InsuranceRepository;
+import xyz.iwasacar.api.domain.loans.entity.Loan;
+import xyz.iwasacar.api.domain.loans.exception.LoanNotFound;
+import xyz.iwasacar.api.domain.loans.repository.LoanRepository;
+import xyz.iwasacar.api.domain.members.entity.Member;
+import xyz.iwasacar.api.domain.members.exception.MemberNotFoundException;
+import xyz.iwasacar.api.domain.members.repository.MemberRepository;
+import xyz.iwasacar.api.domain.products.entity.Product;
+import xyz.iwasacar.api.domain.products.exception.ProductNotFound;
+import xyz.iwasacar.api.domain.products.repository.ProductRepository;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class DefaultHistoryService implements HistoryService {
+
+	private final PurchaseHistoryRepository historyRepository;
+	private final MemberRepository memberRepository;
+	private final ProductRepository productRepository;
+	private final BankRepository bankRepository;
+	private final LoanRepository loanRepository;
+	private final InsuranceRepository insuranceRepository;
+
+	@Transactional
+	@Override
+	public PurchaseHistoryResponse savePurchaseHistory(PurchaseHistoryRequest purchaseHistoryRequest) {
+
+		System.out.println(purchaseHistoryRequest.toString());
+
+		Member member = memberRepository.findById(purchaseHistoryRequest.getMemberId()).orElseThrow(
+			MemberNotFoundException::new);
+
+		Product product = productRepository.findById(purchaseHistoryRequest.getProductId()).orElseThrow(
+			ProductNotFound::new);
+
+		Bank bank = bankRepository.findById(purchaseHistoryRequest.getBankId()).orElseThrow(BankNotFound::new);
+
+		Loan loan = loanRepository.findById(purchaseHistoryRequest.getLoanId()).orElseThrow(LoanNotFound::new);
+
+		Insurance insurance = insuranceRepository.findById(purchaseHistoryRequest.getInsuranceId()).orElseThrow(
+			InsuranceNotFound::new);
+
+		PurchaseHistory purchaseHistory = PurchaseHistory.builder()
+			.member(member)
+			.product(product)
+			.bank(bank)
+			.loan(loan)
+			.insurance(insurance)
+			.zipCode(
+				purchaseHistoryRequest.getZipCode())
+			.address(purchaseHistoryRequest.getAddress())
+			.addressDetail(
+				purchaseHistoryRequest.getAddress())
+			.accountNumber(purchaseHistoryRequest.getAccountNumber())
+			.accountHolder(
+				purchaseHistoryRequest.getAccountHolder())
+			.deliverySchedule(purchaseHistoryRequest.getDeliverySchedule())
+			.status(EntityStatus.CREATED).build();
+
+		PurchaseHistory savedpurchaseHistory = historyRepository.save(purchaseHistory);
+
+		PurchaseHistoryResponse purchaseHistoryResponse = PurchaseHistoryResponse.of(savedpurchaseHistory);
+
+		return purchaseHistoryResponse;
+	}
+}

--- a/src/main/java/xyz/iwasacar/api/domain/histories/service/HistoryService.java
+++ b/src/main/java/xyz/iwasacar/api/domain/histories/service/HistoryService.java
@@ -1,0 +1,9 @@
+package xyz.iwasacar.api.domain.histories.service;
+
+import xyz.iwasacar.api.domain.histories.dto.request.PurchaseHistoryRequest;
+import xyz.iwasacar.api.domain.histories.dto.response.PurchaseHistoryResponse;
+
+public interface HistoryService {
+
+	PurchaseHistoryResponse savePurchaseHistory(PurchaseHistoryRequest phr);
+}

--- a/src/main/java/xyz/iwasacar/api/domain/insurances/exception/InsuranceNotFound.java
+++ b/src/main/java/xyz/iwasacar/api/domain/insurances/exception/InsuranceNotFound.java
@@ -1,0 +1,12 @@
+package xyz.iwasacar.api.domain.insurances.exception;
+
+import xyz.iwasacar.api.common.exception.base.BaseAbstractException;
+import xyz.iwasacar.api.common.exception.base.ExceptionStatus;
+
+public class InsuranceNotFound extends BaseAbstractException {
+
+	public InsuranceNotFound() {
+		super(ExceptionStatus.Insurance_NOT_FOUNT);
+	}
+
+}

--- a/src/main/java/xyz/iwasacar/api/domain/loans/exception/LoanNotFound.java
+++ b/src/main/java/xyz/iwasacar/api/domain/loans/exception/LoanNotFound.java
@@ -1,0 +1,12 @@
+package xyz.iwasacar.api.domain.loans.exception;
+
+import xyz.iwasacar.api.common.exception.base.BaseAbstractException;
+import xyz.iwasacar.api.common.exception.base.ExceptionStatus;
+
+public class LoanNotFound extends BaseAbstractException {
+
+	public LoanNotFound() {
+		super(ExceptionStatus.Loan_NOT_FOUNT);
+	}
+
+}

--- a/src/main/java/xyz/iwasacar/api/domain/products/entity/Product.java
+++ b/src/main/java/xyz/iwasacar/api/domain/products/entity/Product.java
@@ -141,4 +141,8 @@ public class Product {
 		this.status = EntityStatus.CREATED;
 	}
 
+	public static Product changeLabel(Product product, Label newLabel) {
+		product.label = newLabel;
+		return product;
+	}
 }

--- a/src/main/resources/logs/log4j2-prod.xml
+++ b/src/main/resources/logs/log4j2-prod.xml
@@ -50,6 +50,11 @@
         <root level="INFO">
             <appender-ref ref="console"/>
         </root>
+
+        <logger name="xyz.iwasacar.api" level="info" additivity="false">
+            <appender-ref ref="console"/>
+            <appender-ref ref="file"/>
+        </logger>
     </Loggers>
 
 </Configuration>

--- a/src/main/resources/logs/log4j2-prod.xml
+++ b/src/main/resources/logs/log4j2-prod.xml
@@ -49,12 +49,8 @@
     <Loggers>
         <root level="INFO">
             <appender-ref ref="console"/>
-        </root>
-
-        <logger name="xyz.iwasacar.api" level="info" additivity="false">
-            <appender-ref ref="console"/>
             <appender-ref ref="file"/>
-        </logger>
+        </root>
     </Loggers>
 
 </Configuration>


### PR DESCRIPTION
## 구현 기능

* 구매 폼을 받고 purchase_histories 테이블에 저장할 데이터를 모아서 저장 및 주문 완료 페이지에 필요한 데이터 반환

## 세부 작업 내용

* [ ] Id로 받아서 객체로 저장
* [ ] 사용자에게 보여줄 정보만 다시 반환

### 관련 이슈

* #3 


